### PR TITLE
Updating for 3.2 forms

### DIFF
--- a/code/GoogleAddressField.php
+++ b/code/GoogleAddressField.php
@@ -35,6 +35,18 @@ class GoogleAddressField extends TextField {
 	public function setAllowByPass($b) {$this->allowByPass = $b;}
 
 	/**
+	*
+	* @var Boolean
+	*/
+	protected $clearOnLoad = true;
+
+	/**
+	 * Do you want the field cleared on load
+	 * @param Boolean
+	 */
+	public function setClearOnLoad($b) {$this->clearOnLoad = $b;}
+
+	/**
 	 * JS file used to run this field
 	 * @var String
 	 */
@@ -174,10 +186,11 @@ class GoogleAddressField extends TextField {
 				.setVar('errorMessageMoreSpecific', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_MORE_SPECIFIC", "Error: please enter a more specific location."))."')
 				.setVar('errorMessageAddressNotFound', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_ADDRESS_NOT_FOUND", "Error: sorry, address could not be found."))."')
 				.setVar('findNewAddressText', '".Convert::raw2js(_t("GoogleAddressField.FIND_NEW_ADDRESS", "Find Alternative Address"))."')
-				.setVar('useSensor', ".Convert::raw2js($this->userSensor ? "true" : "false").")
+				.setVar('useSensor', ".Convert::raw2js($this->useSensor ? "true" : "false").")
 				.setVar('relatedFields', ".Convert::raw2json($this->getFieldMap()).")
 				.setVar('googleStaticMapLink', '".Convert::raw2js($this->googleStaticMapLink)."')
 				.setVar('linkLabelToViewMap', '".Convert::raw2js(_t("GoogleAddressField.LINK_LABEL_TO_VIEW_MAP", "view map"))."')
+				.setvar('clearOnLoad', ".Convert::raw2js($this->clearOnLoad ? "true" : "false").")
 				.init();";
 	}
 

--- a/code/GoogleAddressField.php
+++ b/code/GoogleAddressField.php
@@ -170,7 +170,7 @@ class GoogleAddressField extends TextField {
 	 */
 	protected function getJavascript(){
 		return "
-			var GoogleAddressField".$this->id()." = new GoogleAddressField( '".Convert::raw2js($this->getName())."')
+			var GoogleAddressField".$this->id()." = new GoogleAddressField( '" . Convert::raw2js($this->getForm()->FormName()) . "_" . Convert::raw2js($this->getName()) . "')
 				.setVar('errorMessageMoreSpecific', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_MORE_SPECIFIC", "Error: please enter a more specific location."))."')
 				.setVar('errorMessageAddressNotFound', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_ADDRESS_NOT_FOUND", "Error: sorry, address could not be found."))."')
 				.setVar('findNewAddressText', '".Convert::raw2js(_t("GoogleAddressField.FIND_NEW_ADDRESS", "Find Alternative Address"))."')

--- a/code/GoogleAddressField.php
+++ b/code/GoogleAddressField.php
@@ -182,16 +182,25 @@ class GoogleAddressField extends TextField {
 	 */
 	protected function getJavascript(){
 		return "
-			var GoogleAddressField".$this->id()." = new GoogleAddressField( '" . Convert::raw2js($this->getForm()->FormName()) . "_" . Convert::raw2js($this->getName()) . "')
-				.setVar('errorMessageMoreSpecific', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_MORE_SPECIFIC", "Error: please enter a more specific location."))."')
-				.setVar('errorMessageAddressNotFound', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_ADDRESS_NOT_FOUND", "Error: sorry, address could not be found."))."')
-				.setVar('findNewAddressText', '".Convert::raw2js(_t("GoogleAddressField.FIND_NEW_ADDRESS", "Find Alternative Address"))."')
-				.setVar('useSensor', ".Convert::raw2js($this->useSensor ? "true" : "false").")
-				.setVar('relatedFields', ".Convert::raw2json($this->getFieldMap()).")
-				.setVar('googleStaticMapLink', '".Convert::raw2js($this->googleStaticMapLink)."')
-				.setVar('linkLabelToViewMap', '".Convert::raw2js(_t("GoogleAddressField.LINK_LABEL_TO_VIEW_MAP", "view map"))."')
-				.setVar('clearOnLoad', ".Convert::raw2js($this->clearOnLoad ? "true" : "false").")
-				.init();";
+			(function($) {
+				$.entwine(function($){
+					$('.text.googleaddress').entwine({
+						onmatch : function(){
+							var GoogleAddressField".$this->id()." = new GoogleAddressField( '" . Convert::raw2js($this->getForm()->FormName()) . "_" . Convert::raw2js($this->getName()) . "')
+								.setVar('errorMessageMoreSpecific', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_MORE_SPECIFIC", "Error: please enter a more specific location."))."')
+								.setVar('errorMessageAddressNotFound', '".Convert::raw2js(_t("GoogleAddressField.ERROR_MESSAGE_ADDRESS_NOT_FOUND", "Error: sorry, address could not be found."))."')
+								.setVar('findNewAddressText', '".Convert::raw2js(_t("GoogleAddressField.FIND_NEW_ADDRESS", "Find Alternative Address"))."')
+								.setVar('useSensor', ".Convert::raw2js($this->useSensor ? "true" : "false").")
+								.setVar('relatedFields', ".Convert::raw2json($this->getFieldMap()).")
+								.setVar('googleStaticMapLink', '".Convert::raw2js($this->googleStaticMapLink)."')
+								.setVar('linkLabelToViewMap', '".Convert::raw2js(_t("GoogleAddressField.LINK_LABEL_TO_VIEW_MAP", "view map"))."')
+								.setVar('clearOnLoad', ".Convert::raw2js($this->clearOnLoad ? "true" : "false").")
+								.init();
+							}
+					});
+				});
+			}(jQuery));
+		";
 	}
 
 

--- a/code/GoogleAddressField.php
+++ b/code/GoogleAddressField.php
@@ -190,7 +190,7 @@ class GoogleAddressField extends TextField {
 				.setVar('relatedFields', ".Convert::raw2json($this->getFieldMap()).")
 				.setVar('googleStaticMapLink', '".Convert::raw2js($this->googleStaticMapLink)."')
 				.setVar('linkLabelToViewMap', '".Convert::raw2js(_t("GoogleAddressField.LINK_LABEL_TO_VIEW_MAP", "view map"))."')
-				.setvar('clearOnLoad', ".Convert::raw2js($this->clearOnLoad ? "true" : "false").")
+				.setVar('clearOnLoad', ".Convert::raw2js($this->clearOnLoad ? "true" : "false").")
 				.init();";
 	}
 

--- a/code/GoogleAddressField.php
+++ b/code/GoogleAddressField.php
@@ -196,7 +196,7 @@ class GoogleAddressField extends TextField {
 								.setVar('linkLabelToViewMap', '".Convert::raw2js(_t("GoogleAddressField.LINK_LABEL_TO_VIEW_MAP", "view map"))."')
 								.setVar('clearOnLoad', ".Convert::raw2js($this->clearOnLoad ? "true" : "false").")
 								.init();
-							}
+						}
 					});
 				});
 			}(jQuery));

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require":{
-		"silverstripe/framework": "~3.1"
+		"silverstripe/framework": "~3.2"
 	},
 	"extra": {
 		"installer-name": "google_address_field"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require":{
-		"silverstripe/framework": "~3.2"
+		"silverstripe/framework": "3.2.*"
 	},
 	"extra": {
 		"installer-name": "google_address_field"

--- a/javascript/GoogleAddressField.js
+++ b/javascript/GoogleAddressField.js
@@ -66,6 +66,12 @@ var GoogleAddressField = function(fieldName) {
 		useSensor: false,
 
 		/**
+		 * should we clear the field on load?
+		 * @var Boolean
+		 */
+		clearOnLoad: true,
+
+		/**
 		 *
 		 * @var autocomplete object provided by Google
 		 */
@@ -283,8 +289,10 @@ var GoogleAddressField = function(fieldName) {
 			geocodingFieldVars.entryFieldHolder.find(geocodingFieldVars.viewGoogleMapLinkSelector).attr("target", "_googleMap");
 			if(geocodingFieldVars.entryField.val().length > 0) {
 				//to do - to be completed!
-				//geocodingFieldVars.entryField.attr("placeholder", geocodingFieldVars.entryField.val());;
-				//geocodingFieldVars.entryField.val("")
+				if(geocodingFieldVars.clearOnLoad){
+					geocodingFieldVars.entryField.attr("placeholder", geocodingFieldVars.entryField.val());
+					geocodingFieldVars.entryField.val("");
+				}
 				//google.maps.event.trigger(geocodingFieldVars.autocomplete, 'place_changed');
 				//console.debug(geocodingFieldVars.autocomplete);
 			}

--- a/javascript/GoogleAddressField.js
+++ b/javascript/GoogleAddressField.js
@@ -184,8 +184,8 @@ var GoogleAddressField = function(fieldName) {
 				return ;
 			}
 
-			geocodingFieldVars.entryFieldHolder = jQuery('#'+geocodingFieldVars.fieldName);
-			geocodingFieldVars.entryField = geocodingFieldVars.entryFieldHolder.find('input[name="'+geocodingFieldVars.fieldName+'"], textarea[name="'+geocodingFieldVars.fieldName+'"]');
+			geocodingFieldVars.entryFieldHolder = jQuery('#' + geocodingFieldVars.fieldName + '_Holder');
+			geocodingFieldVars.entryField = geocodingFieldVars.entryFieldHolder.find('#' + geocodingFieldVars.fieldName);
 			geocodingFieldVars.entryFieldRightLabel = geocodingFieldVars.entryFieldHolder.find('label.right');
 			geocodingFieldVars.entryFieldLeftLabel = geocodingFieldVars.entryFieldHolder.find('label.left');
 
@@ -283,8 +283,8 @@ var GoogleAddressField = function(fieldName) {
 			geocodingFieldVars.entryFieldHolder.find(geocodingFieldVars.viewGoogleMapLinkSelector).attr("target", "_googleMap");
 			if(geocodingFieldVars.entryField.val().length > 0) {
 				//to do - to be completed!
-				geocodingFieldVars.entryField.attr("placeholder", geocodingFieldVars.entryField.val());;
-				geocodingFieldVars.entryField.val("")
+				//geocodingFieldVars.entryField.attr("placeholder", geocodingFieldVars.entryField.val());;
+				//geocodingFieldVars.entryField.val("")
 				//google.maps.event.trigger(geocodingFieldVars.autocomplete, 'place_changed');
 				//console.debug(geocodingFieldVars.autocomplete);
 			}
@@ -294,7 +294,9 @@ var GoogleAddressField = function(fieldName) {
 			var updated = false;
 			var place = geocodingFieldVars.autocomplete.getPlace();
 			geocodingFieldVars.entryField.attr("data-has-result", "no");
-			if(geocodingFieldVars.debug) {console.log(place);}
+			if(geocodingFieldVars.debug) {
+				console.log(place);
+			}
 			var placeIsSpecificEnough = false;
 			for (var i = 0; i < place.types.length; i++) {
 				type = place.types[i];
@@ -319,6 +321,11 @@ var GoogleAddressField = function(fieldName) {
 							long_name: place.formatted_address,
 							short_name: place.formatted_address,
 							types: ["formatted_address"]
+						},
+						{
+							latitude: place.geometry.location.lat(),
+							longitude: place.geometry.location.lng(),
+							types: ["location"]
 						}
 					);
 					for (var formField in geocodingFieldVars.relatedFields) {
@@ -329,21 +336,31 @@ var GoogleAddressField = function(fieldName) {
 						var fieldToSet = jQuery("input[name='"+formField+"'],select[name='"+formField+"'],textarea[name='"+formField+"']");
 						if(fieldToSet.length > 0) {
 							fieldToSet.show().val("");
-							if(geocodingFieldVars.debug) {console.debug("- checking form field: "+formField+" now searching for data ...");}
+							if(geocodingFieldVars.debug) {
+								console.debug("- checking form field: "+formField+" now searching for data ...");
+							}
 							for (var j = 0; j < place.address_components.length; j++) {
-								if(geocodingFieldVars.debug) {console.debug("- -----  ----- ----- provided information: "+place.address_components[j].long_name);}
+								if(geocodingFieldVars.debug) {
+									console.debug("- -----  ----- ----- provided information: "+place.address_components[j].long_name);
+								}
 								for (var k = 0; k < place.address_components[j].types.length; k++) {
 									var googleType = place.address_components[j].types[k];
-									if(geocodingFieldVars.debug) {console.debug("- ----- ----- ----- ----- ----- ----- found Google Info for: "+googleType);}
+									if(geocodingFieldVars.debug) {
+										console.debug("- ----- ----- ----- ----- ----- ----- found Google Info for: "+googleType);
+									}
 									//if(geocodingFieldVars.debug) {console.log(geocodingFieldVars.relatedFields[formField]);}
 									for (var fieldType in geocodingFieldVars.relatedFields[formField]) {
-										if(geocodingFieldVars.debug) {console.debug("- ----- ----- ----- ----- ----- ----- ----- ----- ----- with form field checking: "+fieldType+" is the same as google type: "+googleType);}
+										if(geocodingFieldVars.debug) {
+											console.debug("- ----- ----- ----- ----- ----- ----- ----- ----- ----- with form field checking: "+fieldType+" is the same as google type: "+googleType);
+										}
 										if (fieldType == googleType) {
 											var googleVariable = geocodingFieldVars.relatedFields[formField][fieldType];
 											var value = place.address_components[j][googleVariable];
 											if(jQuery.inArray(value, previousValues) == -1) {
 												previousValues.push(value);
-												if(geocodingFieldVars.debug) {console.debug("- ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** setting: "+formField+" to "+value+", using "+googleVariable+" in google address");}
+												if(geocodingFieldVars.debug) {
+													console.debug("- ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** setting: "+formField+" to "+value+", using "+googleVariable+" in google address");
+												}
 												previousValueForThisFormField = "";
 												if(googleType == "subpremise") {
 													value = value + "/";
@@ -362,7 +379,9 @@ var GoogleAddressField = function(fieldName) {
 												//holderToSet.addClass("geoCodingSet");
 											}
 											else {
-												if(geocodingFieldVars.debug) {console.debug("- ----- ----- ----- ----- ----- ----- ----- ----- ----- data already used: "+value);}
+												if(geocodingFieldVars.debug) {
+													console.debug("- ----- ----- ----- ----- ----- ----- ----- ----- ----- data already used: "+value);
+												}
 											}
 										}
 									}

--- a/javascript/GoogleAddressField.js
+++ b/javascript/GoogleAddressField.js
@@ -1,188 +1,186 @@
 /**
- * This JS comes with the GoogleAddressField Field.
- *
- * It allows the user to find their address using the Google
- * GeoCoding API.
- *
- * @todo: integrate with GeoCoder for lookups of previous addresses... see http://jsfiddle.net/YphZw/
- *
- * @see: https://developers.google.com/maps/documentation/javascript/places-autocomplete
- *
- */
+* This JS comes with the GoogleAddressField Field.
+*
+* It allows the user to find their address using the Google
+* GeoCoding API.
+*
+* @todo: integrate with GeoCoder for lookups of previous addresses... see http://jsfiddle.net/YphZw/
+*
+* @see: https://developers.google.com/maps/documentation/javascript/places-autocomplete
+*
+*/
 
-
-var GoogleAddressField = function(fieldName) {
-
+function GoogleAddressField(fieldName) {
 	var geocodingFieldVars = {
 
 		/**
-		 * @var Boolean
-		 */
+		* @var Boolean
+		*/
 		debug: false,
 
 		/**
-		 * name of the html field (e.g. MyInputField)
-		 * this is provided by PHP using a small customScript
-		 *
-		 * @var String
-		 */
+		* name of the html field (e.g. MyInputField)
+		* this is provided by PHP using a small customScript
+		*
+		* @var String
+		*/
 		fieldName: fieldName,
 
 		/**
-		 * object that is being used to find the address.
-		 * basically the jquery object of the input field in html
-		 * This is set in the init method
-		 * @var jQueryObject
-		 */
+		* object that is being used to find the address.
+		* basically the jquery object of the input field in html
+		* This is set in the init method
+		* @var jQueryObject
+		*/
 		entryField: null,
 
 		/**
-		 * div holding the input
-		 * basically the jquery object of the input field in html
-		 * This is set in the init method
-		 * @var jQueryObject
-		 */
+		* div holding the input
+		* basically the jquery object of the input field in html
+		* This is set in the init method
+		* @var jQueryObject
+		*/
 		entryFieldHolder: null,
 
 		/**
-		 * Right Label
-		 * This is set in the init method
-		 * @var jQueryObject
-		 */
+		* Right Label
+		* This is set in the init method
+		* @var jQueryObject
+		*/
 		entryFieldRightLabel: null,
 
 		/**
-		 * Left Label
-		 * This is set in the init method
-		 * @var jQueryObject
-		 */
+		* Left Label
+		* This is set in the init method
+		* @var jQueryObject
+		*/
 		entryFieldLeftLabel: null,
 
 		/**
-		 * should we use the sensor on mobile
-		 * phones to help?
-		 * @var Boolean
-		 */
+		* should we use the sensor on mobile
+		* phones to help?
+		* @var Boolean
+		*/
 		useSensor: false,
 
 		/**
-		 * should we clear the field on load?
-		 * @var Boolean
-		 */
+		* should we clear the field on load?
+		* @var Boolean
+		*/
 		clearOnLoad: true,
 
 		/**
-		 *
-		 * @var autocomplete object provided by Google
-		 */
+		*
+		* @var autocomplete object provided by Google
+		*/
 		autocomplete: null,
 
 		/**
-		 * based on format FormField: [GeocodingAddressType: format]
-		 *    Address1: {'subpremise': 'short_name', 'street_number': 'short_name', 'route': 'long_name'},
-		 *    Address2: {'locality': 'long_name'},
-		 *    City: {'administrative_area_level_1': 'short_name'},
-		 *    Country: {'country': 'long_name'},
-		 *    PostcalCode: {'postal_code': 'short_name'}
-		 *
-		 * @var JSON
-		 */
+		* based on format FormField: [GeocodingAddressType: format]
+		*    Address1: {'subpremise': 'short_name', 'street_number': 'short_name', 'route': 'long_name'},
+		*    Address2: {'locality': 'long_name'},
+		*    City: {'administrative_area_level_1': 'short_name'},
+		*    Country: {'country': 'long_name'},
+		*    PostcalCode: {'postal_code': 'short_name'}
+		*
+		* @var JSON
+		*/
 		relatedFields: {},
 
 		/**
-		 *
-		 * @var String
-		 */
+		*
+		* @var String
+		*/
 		findNewAddressText: "",
 
 		/**
-		 *
-		 * @var String
-		 */
+		*
+		* @var String
+		*/
 		errorMessageMoreSpecific: "",
 
 		/**
-		 *
-		 * @var String
-		 */
+		*
+		* @var String
+		*/
 		errorMessageAddressNotFound: "",
 
 		/**
-		 * when the Coding field has text...
-		 * @var string
-		 */
+		* when the Coding field has text...
+		* @var string
+		*/
 		hasTextClass: "hasText",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		useMeClass: "useMe",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		selectedClass: "selected",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		bypassSelector: "a.bypassGoogleGeocoding",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		viewGoogleMapLinkSelector: "a.viewGoogleMapLink",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		classForUncompletedField: "holder-required",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		googleStaticMapLink: "",
 
 		/**
-		 * default witdth of static image
-		 * @var Int
-		 */
+		* default witdth of static image
+		* @var Int
+		*/
 		defaultWidthOfStaticImage: 300,
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		urlForViewGoogleMapLink: "http://maps.google.com/maps/search/",
 
 		/**
-		 * @var string
-		 */
+		* @var string
+		*/
 		linkLabelToViewMap: "View Map",
 
 		/**
-		 * percentage of fields that need to be completed.
-		 * @float
-		 */
+		* percentage of fields that need to be completed.
+		* @float
+		*/
 		percentageToBeCompleted: 0.25,
 
 		/**
-		 * we look for these in the address to make sure it is an actual address
-		 * not a region or something less specific than an address.
-		 * @array
-		 */
+		* we look for these in the address to make sure it is an actual address
+		* not a region or something less specific than an address.
+		* @array
+		*/
 		specificEnoughPlaceTypes: ["street_address", "subpremise"],
 
 		/**
-		 * Restrict search to country (currently only one country at the time is supported)
-		 * @var String
-		 */
+		* Restrict search to country (currently only one country at the time is supported)
+		* @var String
+		*/
 		country: "",
 
 		/**
-		 *
-		 * this method sets up all the listeners
-		 * and the basic state.
-		 */
+		*
+		* this method sets up all the listeners
+		* and the basic state.
+		*/
 		init: function () {
 
 			if(typeof google === "undefined") {
@@ -224,50 +222,50 @@ var GoogleAddressField = function(fieldName) {
 
 			//add listeners
 			geocodingFieldVars.entryField
-				.focus(
-					function(){
-						geocodingFieldVars.hideFields();
-						//use sensor ..
-						if(geocodingFieldVars.useSensor) {
-							if (navigator.geolocation) {
-								navigator.geolocation.getCurrentPosition(
-									function(position) {
-										var geolocation = new google.maps.LatLng(position.coords.latitude,position.coords.longitude);
-										geocodingFieldVars.autocomplete.setBounds(new google.maps.LatLngBounds(geolocation, geolocation));
-									}
-								);
-							}
+			.focus(
+				function(){
+					geocodingFieldVars.hideFields();
+					//use sensor ..
+					if(geocodingFieldVars.useSensor) {
+						if (navigator.geolocation) {
+							navigator.geolocation.getCurrentPosition(
+								function(position) {
+									var geolocation = new google.maps.LatLng(position.coords.latitude,position.coords.longitude);
+									geocodingFieldVars.autocomplete.setBounds(new google.maps.LatLngBounds(geolocation, geolocation));
+								}
+							);
 						}
+					}
+					geocodingFieldVars.updateEntryFieldStatus();
+				}
+			)
+			.focusout(
+				function(){
+					if(geocodingFieldVars.hasResults()) {
+						geocodingFieldVars.showFields();
+					}
+					geocodingFieldVars.updateEntryFieldStatus();
+				}
+			)
+			.keypress(
+				function(e){
+					var code = e.which;
+					if (code == 13 ) return false;
+				}
+			)
+			.on(
+				'input propertychange paste',
+				function(e){
+					//tab
+					if(geocodingFieldVars.hasResults()) {
+						geocodingFieldVars.clearFields();
+						geocodingFieldVars.setResults( "no");
 						geocodingFieldVars.updateEntryFieldStatus();
-					}
-				)
-				.focusout(
-					function(){
-						if(geocodingFieldVars.hasResults()) {
-							geocodingFieldVars.showFields();
-						}
-						geocodingFieldVars.updateEntryFieldStatus();
-					}
-				)
-				.keypress(
-					function(e){
-						var code = e.which;
-						if (code == 13 ) return false;
-					}
-				)
-				.on(
-					'input propertychange paste',
-					function(e){
-						//tab
-						if(geocodingFieldVars.hasResults()) {
-							geocodingFieldVars.clearFields();
-							geocodingFieldVars.setResults( "no");
-							geocodingFieldVars.updateEntryFieldStatus();
 
-						}
-						//or...if ( e.which == 13 ) e.preventDefault();
 					}
-				);
+					//or...if ( e.which == 13 ) e.preventDefault();
+				}
+			);
 			//bypass
 			geocodingFieldVars.entryFieldHolder.find(geocodingFieldVars.bypassSelector).click(
 				function(e){
@@ -410,8 +408,8 @@ var GoogleAddressField = function(fieldName) {
 				geocodingFieldVars.entryField.val(geocodingFieldVars.errorMessageMoreSpecific);
 				//reset links
 				mapLink
-					.attr("href", geocodingFieldVars.urlForViewGoogleMapLink)
-					.html("");
+				.attr("href", geocodingFieldVars.urlForViewGoogleMapLink)
+				.html("");
 			}
 			geocodingFieldVars.updateEntryFieldStatus();
 			if(geocodingFieldVars.hasResults()) {
@@ -420,8 +418,8 @@ var GoogleAddressField = function(fieldName) {
 		},
 
 		/**
-		 * shows the address fields
-		 */
+		* shows the address fields
+		*/
 		showFields: function(){
 			//hide fields to be completed for now...
 			for (var formField in geocodingFieldVars.relatedFields) {
@@ -438,8 +436,8 @@ var GoogleAddressField = function(fieldName) {
 		},
 
 		/**
-		 * hides the address fields
-		 */
+		* hides the address fields
+		*/
 		hideFields: function(){
 			var makeItRequired = false;
 			//hide fields to be completed for now...
@@ -466,9 +464,9 @@ var GoogleAddressField = function(fieldName) {
 		},
 
 		/**
-		 *
-		 * @return Boolean
-		 */
+		*
+		* @return Boolean
+		*/
 		alreadyHasValues: function(){
 			var empty = 0;
 			var count = 0;
@@ -490,8 +488,8 @@ var GoogleAddressField = function(fieldName) {
 		},
 
 		/**
-		 * removes all the data from the address fields
-		 */
+		* removes all the data from the address fields
+		*/
 		clearFields: function(){
 			//hide fields to be completed for now...
 			for (var formField in geocodingFieldVars.relatedFields) {
@@ -500,26 +498,26 @@ var GoogleAddressField = function(fieldName) {
 		},
 
 		/**
-		 * shows the user that there is a result.
-		 *
-		 * @param string
-		 */
+		* shows the user that there is a result.
+		*
+		* @param string
+		*/
 		setResults: function(resultAsYesOrNo) {
 			return  geocodingFieldVars.entryField.attr("data-has-result", resultAsYesOrNo);
 		},
 
 		/**
-		 * tells us if results have been found
-		 *
-		 * @return Boolean
-		 */
+		* tells us if results have been found
+		*
+		* @return Boolean
+		*/
 		hasResults: function() {
 			return geocodingFieldVars.entryField.attr("data-has-result") == "yes" ? true : false
 		},
 
 		/**
-		 * sets up all the various class options based on the current status
-		 */
+		* sets up all the various class options based on the current status
+		*/
 		updateEntryFieldStatus: function() {
 			var value =  geocodingFieldVars.entryField.val();
 			var hasResult =  geocodingFieldVars.hasResults();
@@ -547,9 +545,9 @@ var GoogleAddressField = function(fieldName) {
 		},
 
 		/**
-		 *
-		 * @return NULL | String
-		 */
+		*
+		* @return NULL | String
+		*/
 		getStaticMapImage: function(escapedLocation) {
 			if(geocodingFieldVars.googleStaticMapLink) {
 				var string = geocodingFieldVars.googleStaticMapLink;
@@ -567,15 +565,13 @@ var GoogleAddressField = function(fieldName) {
 				return string;
 			}
 		}
-
 	}
-
 
 	// Expose public API
 	return {
 		getVar: function( variableName ) {
-			if ( geocodingFieldVars.hasOwnProperty( variableName ) ) {
-				return geocodingFieldVars[ variableName ];
+			if (geocodingFieldVars.hasOwnProperty(variableName)) {
+				return geocodingFieldVars[variableName];
 			}
 		},
 		setVar: function(variableName, value) {
@@ -586,7 +582,5 @@ var GoogleAddressField = function(fieldName) {
 			geocodingFieldVars.init();
 			return this;
 		}
-
 	}
-
 }


### PR DESCRIPTION
Updated the module to work with the new 3.2 ID naming conventions.
Added the option for the form to not clear the selection field on page load.
Added the ability to pull the latitude and longitude information from the address as well.
